### PR TITLE
fix: correct malformed KDoc opener in DoesItBuildRule

### DIFF
--- a/src/main/kotlin/nl/utwente/processing/pmd/rules/DoesItBuildRule.kt
+++ b/src/main/kotlin/nl/utwente/processing/pmd/rules/DoesItBuildRule.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.io.InputStreamReader
 import java.util.concurrent.TimeUnit
 
-*/**
+/**
  * Rule that checks whether the Processing sketch builds successfully using processing-java.
  * If the build fails, a violation is reported.
  */


### PR DESCRIPTION
## Summary
- `src/main/kotlin/nl/utwente/processing/pmd/rules/DoesItBuildRule.kt:13` opens its class-level KDoc with `*/**` instead of `/**`. The leading `*` is a stray top-level token, and Kotlin rejects the file with `Expecting a top level declaration`.
- As a result `mvn clean package` fails on a clean checkout — `DoesItBuildRule` is the only Kotlin rule that doesn't compile, which fails the kotlin-maven-plugin step before the rest of the project can be packaged.
- The typo was introduced in Addzyyy/Zita commit `e2179bb` ("new rules added and updated readme", #9). The repository's existing GitHub Actions workflow (`merge-to-dev.yml`) only triggers on PRs to a `dev` branch, so the broken state on `main` was never exercised by CI.

## Fix
Single-character change: `*/**` → `/**` on line 13. Comment content is unchanged.

## Test plan
- [x] `mvn -B clean package` succeeds on a fresh checkout, producing `target/Zita.jar` (~8.3 MB shaded uber-jar containing all Kotlin rules)
- [x] `java -jar target/Zita.jar --project <sketch_dir> --rules <rules.xml> --renderer zita` runs end-to-end and emits violations against a sample Processing sketch
- [ ] (Reviewer) Confirm a clean clone of `main` + this PR builds without further patches