### PR TITLE
fix: declare 'category' property descriptors on rules referenced by rules.xml

### DIFF
--- a/src/main/kotlin/nl/utwente/processing/pmd/rules/HasClassWithConstructorRule.kt
+++ b/src/main/kotlin/nl/utwente/processing/pmd/rules/HasClassWithConstructorRule.kt
@@ -5,6 +5,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule
+import net.sourceforge.pmd.properties.PropertyDescriptor
+import net.sourceforge.pmd.properties.PropertyFactory
 
 /**
  * Rule that checks if user-defined classes have explicit constructors.
@@ -16,6 +18,19 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule
  * - At least one user-defined class has an explicit constructor
  */
 class HasClassWithConstructorRule : AbstractJavaRule() {
+
+    companion object {
+        private val CATEGORY: PropertyDescriptor<String> =
+            PropertyFactory.stringProperty("category")
+                .desc("Rule category")
+                .defaultValue("default")
+                .build()
+    }
+
+    init {
+        definePropertyDescriptor(CATEGORY)
+    }
+
     private var compilationUnit: ASTCompilationUnit? = null
     private var hasUserDefinedClass = false
     private var hasConstructor = false

--- a/src/main/kotlin/nl/utwente/processing/pmd/rules/HasUsefulEventHandlerRule.kt
+++ b/src/main/kotlin/nl/utwente/processing/pmd/rules/HasUsefulEventHandlerRule.kt
@@ -3,6 +3,8 @@ package nl.utwente.processing.pmd.rules
 import net.sourceforge.pmd.RuleContext
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule
+import net.sourceforge.pmd.properties.PropertyDescriptor
+import net.sourceforge.pmd.properties.PropertyFactory
 import nl.utwente.processing.pmd.symbols.ProcessingApplet
 
 /**
@@ -13,6 +15,19 @@ import nl.utwente.processing.pmd.symbols.ProcessingApplet
  * Additionally, if no event handlers are found at all, a violation is also reported.
  */
 class HasUsefulEventHandlerRule : AbstractJavaRule() {
+
+    companion object {
+        private val CATEGORY: PropertyDescriptor<String> =
+            PropertyFactory.stringProperty("category")
+                .desc("Rule category")
+                .defaultValue("default")
+                .build()
+    }
+
+    init {
+        definePropertyDescriptor(CATEGORY)
+    }
+
     private var foundComplexity = false
     private val eventHandlersToFlag = mutableListOf<ASTMethodDeclaration>()
     private var declaredMethodNames: Set<String> = emptySet()


### PR DESCRIPTION
## Summary
Loading the shipped `src/main/resources/rulesets/rules.xml` currently throws

```
java.lang.IllegalArgumentException: Cannot set non-existent property 'category' on Rule UsefulEventHandlerRule
```

(and similarly for `HasClassWithConstructorRule`) inside `RuleSetFactory.createRuleSets`, called from `PMDRunner.<init>`. As a result **every renderer (`zita`, `student`, `handover`, `html`, `json`, `csv`) fails before producing any output** — the project is unusable end-to-end against its own ruleset on a clean build.

## Root cause
`rules.xml` configures both rules with:

```xml
<properties>
    <property name="category" value="..."/>
</properties>
```

but neither `HasUsefulEventHandlerRule.kt` nor `HasClassWithConstructorRule.kt` calls `definePropertyDescriptor(CATEGORY)`. PMD's `RuleFactory.setPropertyValues` rejects unknown property names rather than ignoring them.

## Fix
Add the `category` `PropertyDescriptor` to both classes, following the established pattern already used in `HasHeaderCommentRule`, `DoesItBuildRule`, `HasLoopRule`, `HasEventHandlerRule`, `Has2DShapesRule`, `HasStandardProcessingStructure`, and `VariableArithmeticRule`. No XML changes needed.

`StudentFeedbackRenderer.getCategoryForRule` (line 350) reads this property as the fallback for rules that aren't listed in `rule-category-mapping.properties` — both of these rules fall into that bucket, so the property is genuinely needed (not just vestigial config). After the fix the two rules show up in the renderer under their declared categories ("Demonstrates-mastery" and "Demonstrates-mastery Oop").

## Test plan
- [x] `mvn -B clean package` succeeds
- [x] `java -jar target/Zita.jar --project <sketch> --rules src/main/resources/rulesets/rules.xml --renderer student` runs end-to-end against the **unmodified** shipped ruleset and emits violations grouped under the correct categories (verified locally)
- [x] Same with `--renderer zita`, `--renderer json`
- [ ] (Reviewer) Repro the original crash on `main` first by running any renderer against the shipped `rules.xml`, then verify this PR resolves it

## Note
This PR depends on #10 (KDoc typo fix in `DoesItBuildRule.kt`) compiling cleanly. If that one is reviewed and merged first, this PR's diff stays minimal as shown.